### PR TITLE
Feature custom hoster

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,8 @@
+Selfhosted vendace backend
+=========================
+
+# Setup 
+
+Copy `config.php.sample` to `config.php` and adjust the values to your needs. 
+
+The webserver needs write permissions to create and later write to the `$PICDIR` directory. 

--- a/backend/config.php.sample
+++ b/backend/config.php.sample
@@ -1,0 +1,12 @@
+<?php
+
+$AUTH_KEY = "Client-ID ede801c7c97f184";
+$PICDIR = "pics/";
+$HOST = "localhost"; 
+$URLFORMAT = "http://$HOST/$PICDIR/[[PICID]]";
+
+
+if( ! file_exists($PICDIR)) {
+	mkdir($PICDIR);
+}
+?>

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,0 +1,31 @@
+<?php
+include("config.php");
+header("Content-Type: application/json");
+
+$headers = array_merge(apache_request_headers(), $_SERVER);
+$authKey = null;
+
+if(isset($headers['HTTP_AUTHORIZATION'])) {
+	$authKey = $headers['HTTP_AUTHORIZATION'];
+} elseif( isset($headers['Authorization'])) {
+	$authKey = $headers['Authorization'];
+}
+
+if($authKey == null || !$authKey === $AUTH_KEY) {
+	echo json_encode(array(null));
+	return -2;
+}
+
+if(! isset($_POST['image'])) {
+	echo json_encode(array(null));
+	return -3;
+}
+
+$imageData = $_POST['image'];
+$imageName = md5($imageData) . ".png";
+
+file_put_contents($PICDIR . "/" . $imageName, $imageData);
+
+echo json_encode(array("data" => array("link" => str_replace("[[PICID]]", $imageName, $URLFORMAT))));
+
+?>

--- a/forms/settings.ui
+++ b/forms/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -68,6 +68,63 @@
            <widget class="QComboBox" name="copyTo"/>
           </item>
          </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_3">
+       <property name="title">
+        <string>Upload URL</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="labelUrl">
+          <property name="text">
+           <string>URL</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="uploadUrl"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_4">
+       <property name="title">
+        <string>Upload Auth</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="labelKey">
+          <property name="text">
+           <string>Authorization Key</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="uploadKey"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_5">
+       <property name="title">
+        <string>Upload Https?</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="labelKey">
+          <property name="text">
+           <string>Replace HTTP with HTTPS</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="uploadHttps"/>
         </item>
        </layout>
       </widget>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -22,3 +22,27 @@ QClipboard::Mode Settings::copyToAsMode() const {
     }
     return QClipboard::Clipboard;
 }
+
+void Settings::setUploadUrl(QString url) {
+    mSettings.setValue(KEY_UPLOAD_URL, url);
+}
+
+QString Settings::uploadUrl() const {
+    return mSettings.value(KEY_UPLOAD_URL).toString();
+}
+
+void Settings::setUploadKey(QString key) {
+    mSettings.setValue(KEY_UPLOAD_KEY, key);
+}
+
+QString Settings::uploadKey() const {
+    return mSettings.value(KEY_UPLOAD_KEY).toString();
+}
+
+void Settings::setUploadHttps(QString mode) {
+    mSettings.setValue(KEY_UPLOAD_HTTPS, mode);
+}
+
+QString Settings::uploadHttps() const {
+    return mSettings.value(KEY_UPLOAD_HTTPS).toString();
+}

--- a/src/Settings.hpp
+++ b/src/Settings.hpp
@@ -7,8 +7,14 @@
 
 #define KEY_EDITOR_PATH "Editor/Path"
 #define KEY_COPY_TO "Upload/CopyTo"
+#define KEY_UPLOAD_URL "Upload/Url"
+#define KEY_UPLOAD_KEY "Upload/Key"
+#define KEY_UPLOAD_HTTPS "Upload/Https"
 #define SETTING_COPY_TO_CLIPBOARD "Clipboard"
 #define SETTING_COPY_TO_SELECTION "Selection"
+#define SETTING_UPLOAD_URL "https://api.imgur.com/3/image"
+#define SETTING_UPLOAD_KEY "Client-ID ede801c7c97f184"
+#define SETTING_UPLOAD_HTTPS "true"
 
 class Settings {
 
@@ -18,6 +24,12 @@ class Settings {
         void setCopyTo(QString mode);
         QString copyTo() const;
         QClipboard::Mode copyToAsMode() const;
+        void setUploadUrl(QString url);
+        QString uploadUrl() const;
+        void setUploadKey(QString key);
+        QString uploadKey() const;
+        void setUploadHttps(QString key);
+        QString uploadHttps() const;
 
     protected:
         QSettings mSettings;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -6,6 +6,21 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent) {
     mUi.setupUi(this);
     mUi.editorPath->setText(mSettings.editorPath());
 
+    if(mSettings.uploadUrl().length() == 0) {
+        mSettings.setUploadUrl(SETTING_UPLOAD_URL);
+    }
+    if(mSettings.uploadKey().length() == 0) {
+        mSettings.setUploadKey(SETTING_UPLOAD_KEY);
+    }
+    mUi.uploadUrl->setText(mSettings.uploadUrl());
+    mUi.uploadKey->setText(mSettings.uploadKey());
+
+    if(mSettings.uploadHttps() == SETTING_UPLOAD_HTTPS) {
+        mUi.uploadHttps->setChecked(true);
+    } else {
+        mUi.uploadHttps->setChecked(false);
+    }
+
     // Add copy options
     mUi.copyTo->insertItem(0, tr("Clipboard"));
     mUi.copyTo->insertItem(1, tr("Selection"));
@@ -14,6 +29,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent) {
     }
 
     connect(mUi.editorPath, SIGNAL(textChanged(QString)), this, SLOT(editorPathChanged(QString)));
+    connect(mUi.uploadUrl, SIGNAL(textChanged(QString)), this, SLOT(uploadUrlChanged(QString)));
+    connect(mUi.uploadKey, SIGNAL(textChanged(QString)), this, SLOT(uploadKeyChanged(QString)));
+    connect(mUi.uploadHttps, SIGNAL(clicked(bool)), this, SLOT(uploadHttpsChanged(bool)));
     connect(mUi.editorPathBrowse, SIGNAL(pressed()), this, SLOT(browseEditorPath()));
     connect(mUi.copyTo, SIGNAL(currentIndexChanged(int)), this, SLOT(copyToChanged(int)));
     connect(mUi.closeButton, SIGNAL(pressed()), this, SLOT(close()));
@@ -21,6 +39,30 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent) {
 
 void SettingsDialog::editorPathChanged(QString path) {
     mSettings.setEditorPath(path);
+}
+
+void SettingsDialog::uploadUrlChanged(QString url) {
+    if(mSettings.uploadUrl().length() == 0) {
+        mSettings.setUploadUrl(SETTING_UPLOAD_URL);
+    } else {
+        mSettings.setUploadUrl(url);
+    }
+}
+
+void SettingsDialog::uploadKeyChanged(QString key) {
+    if(mSettings.uploadKey().length() == 0) {
+        mSettings.setUploadKey(SETTING_UPLOAD_KEY);
+    } else {
+        mSettings.setUploadKey(key);
+    }
+}
+
+void SettingsDialog::uploadHttpsChanged(bool mode) {
+    if(mode) {
+        mSettings.setUploadHttps(SETTING_UPLOAD_HTTPS);
+    } else {
+        mSettings.setUploadHttps("false");
+    }
 }
 
 void SettingsDialog::browseEditorPath() {

--- a/src/SettingsDialog.hpp
+++ b/src/SettingsDialog.hpp
@@ -15,6 +15,9 @@ class SettingsDialog : public QDialog {
 
     protected slots:
         void editorPathChanged(QString);
+        void uploadUrlChanged(QString);
+        void uploadKeyChanged(QString);
+        void uploadHttpsChanged(bool);
         void browseEditorPath();
         void copyToChanged(int);
 

--- a/src/Uploader.cpp
+++ b/src/Uploader.cpp
@@ -4,8 +4,8 @@ Uploader::Uploader(QObject *parent) : QObject(parent) {
 }
 
 QNetworkRequest Uploader::makeRequest() {
-    QNetworkRequest request(QUrl("https://api.imgur.com/3/image"));
-    request.setRawHeader("Authorization", "Client-ID ede801c7c97f184");
+    QNetworkRequest request(QUrl(mSettings.uploadUrl()));
+    request.setRawHeader("Authorization", mSettings.uploadKey().toUtf8());
     return request;
 }
 
@@ -30,5 +30,9 @@ QString Uploader::getUrlFromReply(QNetworkReply *reply) {
         return "";
     }
 
-    return doc.object()["data"].toObject()["link"].toString().replace("http:", "https:");
+    QString url = doc.object()["data"].toObject()["link"].toString();
+    if (mSettings.uploadHttps() == SETTING_UPLOAD_HTTPS) {
+        url = url.replace("http:", "https:");
+    }
+    return url;
 }

--- a/src/Uploader.hpp
+++ b/src/Uploader.hpp
@@ -3,6 +3,7 @@
 
 #include <QtCore>
 #include <QtNetwork>
+#include "Settings.hpp"
 
 class Uploader : public QObject {
 
@@ -13,6 +14,9 @@ class Uploader : public QObject {
         QNetworkRequest makeRequest();
         QHttpMultiPart* makeMultiPart(QIODevice*);
         QString getUrlFromReply(QNetworkReply*);
+
+    protected:
+        Settings mSettings;
 
 };
 


### PR DESCRIPTION
Hi,

I really like vendace! Thanks a lot for this cool tool. 

However, I sometimes screenshot some sensitive data which I don't want to have publicly posted to imgur. I've modified the code to let people configure a foreign image hoster which implements a similar API. I've also added a simple PHP backend script which works with the same API. 
Imgur is still the default, so it should be fully backwards compatible. 

The only that should be fixed is the layout of the settings-dialog window. I couldn't get qt creator to run on machine and I didn't manage to write a nice looking layout structure in pure XML. 

It would be awesome if you could consider adding this feature. 

With best regards,
gehaxelt 

